### PR TITLE
키워드 검색 시 페이지 이동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,8 @@ function App() {
       <Route path="/login" element={<Login />} />
       <Route path="/join" element={<Join />} />
       <Route path="/main" element={<Main />} />
-      <Route path="/" element={<Keyword />} /> {/* 제일 먼저 뜨는 페이지 */}
+      <Route path="/keyword/:keyword" element={<Keyword />} />
+      <Route path="/" element={<Main />} /> {/* 제일 먼저 뜨는 페이지 */}
     </Routes>
   );
 }

--- a/src/components/KeywordNews.jsx
+++ b/src/components/KeywordNews.jsx
@@ -4,20 +4,20 @@ function KeywordNews({ articles, title }) {
   return (
     <div className="keywordnews">
       <h2>{title}</h2>
-      <ul className="news-list">
+      <ul className="keyword-news-list">
         {articles.map((news, idx) => (
-          <li key={idx} className="news-item horizontal">
+          <li key={idx} className="keyword-news-item horizontal">
             <img
               src={news.imageUrl || '/src/assets/default.png'}
               alt="뉴스 썸네일"
-              className="news-thumbnail horizontal"
+              className="keyword-news-thumbnail horizontal"
             />
-            <div className="news-content">
+            <div className="keyword-news-content">
               <div>
-                <p className="news-title">{news.title}</p>
-                <p className="news-summary">{news.summary}</p>
+                <p className="keyword-news-title">{news.title}</p>
+                <p className="keyword-news-summary">{news.summary}</p>
               </div>
-              <p className="news-meta">{news.press} · {news.time}</p>
+              <p className="keyword-news-meta">{news.press} · {news.time}</p>
             </div>
           </li>
         ))}

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -1,9 +1,16 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import '../styles/logo.css';
 
 function Logo() {
+  const navigate = useNavigate();
+
   return (
-    <div className="header-logo">
+    <div
+      className="header-logo"
+      onClick={() => navigate("/main")}
+      style={{ cursor: "pointer" }} // 클릭 가능한 느낌
+    >
       NewSummarize
     </div>
   );

--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -1,13 +1,42 @@
-import React from "react";
-import '../styles/search.css';
+import React, { useState, useEffect } from "react";
+import { useNavigate, useLocation, useParams } from "react-router-dom";
+import "../styles/search.css";
 
 function Search() {
-    return (
-        <div className="header-search">
-            <input type="text" placeholder="Keyword 검색" />
-            <button className="search-button">🔍</button>
-        </div>
-    );
+  const navigate = useNavigate();
+  const location = useLocation();
+  const params = location.pathname.startsWith("/keyword/")
+    ? decodeURIComponent(location.pathname.split("/keyword/")[1])
+    : "";
+
+  const [keyword, setKeyword] = useState("");
+
+  useEffect(() => {
+    if (params) {
+      setKeyword(params); // URL에서 받아온 검색어로 세팅
+    }
+  }, [params]);
+
+  const handleSearch = () => {
+    if (keyword.trim()) {
+      navigate(`/keyword/${encodeURIComponent(keyword)}`);
+    }
+  };
+
+  return (
+    <div className="header-search">
+      <input
+        type="text"
+        placeholder="Keyword 검색"
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleSearch();
+        }}
+      />
+      <button className="search-button" onClick={handleSearch}>🔍</button>
+    </div>
+  );
 }
 
 export default Search;

--- a/src/pages/Keyword.jsx
+++ b/src/pages/Keyword.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useParams } from "react-router-dom"; // 🔹 검색어 가져오기
 import Header from "../components/Header";
 import KeywordNews from "../components/KeywordNews";
 import AISummary from "../components/AISummary";
@@ -30,13 +31,15 @@ const dummyArticles = [
 ];
 
 function Keyword() {
+  const { keyword } = useParams(); // 🔹 URL의 키워드 파라미터 추출
+
   return (
     <div className="keyword-page">
       <Header />
       <main className="keyword-content">
         <div className="keyword-container">
           {/* 좌측 뉴스 영역 */}
-          <KeywordNews articles={dummyArticles} title="News →" />
+          <KeywordNews articles={dummyArticles} title={`"${keyword}" 연관 뉴스`} />
 
           {/* 우측 요약/트래픽 영역 */}
           <div className="keyword-side">

--- a/src/styles/keyword.css
+++ b/src/styles/keyword.css
@@ -11,7 +11,7 @@
   background-color: #f5f6f8;
 }
 
-/* 💡 Main 페이지처럼 가운데 정렬 + 양옆 여백 */
+/* Main 페이지처럼 가운데 정렬 + 양옆 여백 */
 .keyword-container {
   display: flex;
   gap: 24px;

--- a/src/styles/keywordnews.css
+++ b/src/styles/keywordnews.css
@@ -18,7 +18,7 @@
 }
 
 /* 뉴스 리스트 */
-.news-list {
+.keyword-news-list {
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -28,7 +28,7 @@
 }
 
 /* 뉴스 아이템 카드 */
-.news-item.horizontal {
+.keyword-news-item.horizontal {
     display: flex;
     flex-direction: row;
     align-items: flex-start;
@@ -36,15 +36,16 @@
     background-color: #fff;
     border-radius: 12px;
     position: relative;
+    cursor: pointer;
 }
 
-.news-item.horizontal:hover {
+.keyword-news-item.horizontal:hover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     text-decoration: underline;
 }
 
 /* 뉴스 이미지 (좌측) */
-.news-thumbnail.horizontal {
+.keyword-news-thumbnail.horizontal {
     width: 46%;
     aspect-ratio: 3 / 2;
     object-fit: cover;
@@ -54,14 +55,14 @@
 }
 
 /* 텍스트 컨테이너 */
-.news-content {
+.keyword-news-content {
     flex: 1;
     display: flex;
     flex-direction: column;
 }
 
 /* 뉴스 제목 */
-.news-title {
+.keyword-news-title {
     font-size: 17px;
     font-weight: 600;
     color: #333;
@@ -70,7 +71,7 @@
 }
 
 /* 뉴스 요약 */
-.news-summary {
+.keyword-news-summary {
     font-size: 14px;
     color: #555;
     line-height: 1.4;
@@ -79,7 +80,7 @@
 }
 
 /* 뉴스 언론사 · 날짜 */
-.news-meta {
+.keyword-news-meta {
     position: absolute;
     bottom: 6px; 
     font-size: 12px;

--- a/src/styles/mainnews.css
+++ b/src/styles/mainnews.css
@@ -27,6 +27,7 @@
     background-color: #fff;
     border-radius: 12px;
     position: relative;
+    cursor: pointer;
 }
 
 .news-item.horizontal:hover {

--- a/src/styles/recommend.css
+++ b/src/styles/recommend.css
@@ -27,6 +27,7 @@
     border-radius: 12px;
     background-color: #fff;
     transition: box-shadow 0.2s ease;
+    cursor: pointer;
 }
   
 .recommend-item:hover {


### PR DESCRIPTION
1. 시작페이지를 메인페이지로 하고 키워드 검색 시 키워드 페이지로 넘어가게 함
2. 로고 눌렀을 때 메인페이지로 돌아오게 함
3. 뉴스 카드 아이템에 마우스 올렸을 때 손가락 커서로 바뀌게 함