### PR TITLE
1차 카테고리 별 뉴스 페이지 제작

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Join from './pages/Join';
 import Main from './pages/Main';
 import Keyword from './pages/Keyword';
 import My from './pages/My';
+import Cate from './pages/CategoryNews'
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
         <Route path="/join" element={<Join />} />
         <Route path="/main" element={<Main />} />
         <Route path="/my" element={<My />} />
+        <Route path="/cate" element={<Cate />} />
         <Route path="/keyword/:keyword" element={<Keyword />} />
         <Route path="/" element={<Main />} /> {/* 제일 먼저 뜨는 페이지 */}
       </Routes>

--- a/src/pages/CategoryNews.jsx
+++ b/src/pages/CategoryNews.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import Category from '../components/Category';
+import '../styles/categorynews.css';
+
+const dummyArticles = [
+  { id: 1, title: "정치 뉴스 제목", summary: "정치 관련 주요 소식입니다.",
+    img: "https://via.placeholder.com/200x120/1976d2/ffffff?text=Politics"},
+  { id: 2, title: "경제 뉴스 제목", summary: "경제 관련 주요 소식입니다.",
+    img: "https://via.placeholder.com/200x120/4caf50/ffffff?text=Economy"},
+  { id: 3, title: "사회 뉴스 제목", summary: "사회 관련 주요 소식입니다.",
+    img: "https://via.placeholder.com/200x120/ff9800/ffffff?text=Society"},
+  { id: 4, title: "생활/문화 뉴스 제목", summary: "생활/문화 관련 주요 소식입니다.",
+    img: "https://via.placeholder.com/200x120/9c27b0/ffffff?text=Culture"},
+  { id: 5, title: "IT/과학 뉴스 제목", summary: "IT/과학 관련 주요 소식입니다.",
+    img: "https://via.placeholder.com/200x120/03a9f4/ffffff?text=IT"},
+  { id: 6, title: "세계 뉴스 제목", summary: "세계 관련 주요 소식입니다.",
+    img: "https://via.placeholder.com/200x120/ff5722/ffffff?text=World"},
+];
+
+function truncate(text, maxLength) {
+  if (!text) return '';
+  return text.length > maxLength ? text.substring(0, maxLength) + '…' : text;
+}
+
+function CategoryNews({ articles = dummyArticles }) {
+const [selected, setSelected] = useState('HOME');
+const filtered = selected === 'HOME'
+    ? dummyArticles
+    : dummyArticles.filter(news => news.category === selected);
+
+  return (
+    <div className="news-wrapper">
+      <div className="news-list">
+        {articles.map((news) => (
+          <div key={news.id} className="news-item">
+            <div className="news-thumbnail">
+              <img src={news.img} alt="뉴스 썸네일" />
+            </div>
+            <div className="news-content">
+              <h3 className="news-title">{news.title}</h3>
+              <p className="news-summary">{truncate(news.summary, 100)}</p>
+              <div className="news-meta">
+                <span className="news-press">{news.press}</span>
+                <span className="news-time">{news.time}</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default CategoryNews;

--- a/src/pages/My.jsx
+++ b/src/pages/My.jsx
@@ -58,7 +58,7 @@ function MyPage() {
 
         {/* 세로 구분선 */}
         <div className="mypage-vertical-divider"></div>
-
+      
         {/* 본문 */}
         <div className="mypage-content">
           {selectedMenu === "개인정보" && (

--- a/src/styles/categorynews.css
+++ b/src/styles/categorynews.css
@@ -1,0 +1,78 @@
+.news-wrapper {
+  width: 100%;
+  max-width: 800px;      /* 필요시 더 넓게 */
+  margin: 0 auto;
+  background: #f6f7fa;
+  border-radius: 16px;
+  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.04);
+  padding: 40px 0;
+}
+
+.news-list {
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-left: 40px;
+}
+
+.news-item {
+  width: 100%;
+  display: flex;
+  gap: 20px;
+  padding: 16px;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  align-items: center;
+  box-sizing: border-box;
+}
+
+.news-thumbnail img {
+  width: 200px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.news-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.news-title {
+  margin: 0 0 8px 0;
+  font-size: 18px;
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.news-summary {
+  margin: 0 0 8px 0;
+  color: #555;
+  font-size: 15px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.news-meta {
+  display: flex;
+  gap: 8px;
+  font-size: 14px;
+  color: #888;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.news-press {
+  margin-right: 8px;
+  white-space: nowrap;
+}
+
+.news-time {
+  white-space: nowrap;
+}


### PR DESCRIPTION
작업 내용
- 뉴스 리스트 형식을 제작하여 뉴스 사진, 제목, 내용 요약이 나타나게 함.
- 내용 요약이 일정 길이를 초과할 시 '...'으로 축약

코드 내 추가 못한 주석
- news-press : 어느 뉴스에서 제작한건지 나타내는 클래스 (동아일보, 조선일보 등)
- news-time : 뉴스가 작성된 시간을 나타내는 클래스
둘 다 화면 하단에 뭉쳐서 나오길래 클래스 자체는 만들어뒀지만 임시로 만든 데이터에서는 지웠습니다.
데이터를 불러왔을 때 필요하다면 저 클래스들에 사용하면 될 것 같습니다.