### PR TITLE
카테고리 페이지 구현, 키워드 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.5.1"
+        "react-router-dom": "^7.5.1",
+        "recharts": "^2.15.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -261,6 +262,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.3.tgz",
+      "integrity": "sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1354,6 +1364,69 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -1600,6 +1673,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1674,8 +1756,128 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -1695,6 +1897,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1709,6 +1917,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -2019,12 +2237,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2321,6 +2554,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2355,7 +2597,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2458,12 +2699,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -2557,6 +2816,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2687,6 +2955,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -2723,6 +3008,12 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -2771,6 +3062,69 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/resolve-from": {
@@ -2904,6 +3258,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/turbo-stream": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
@@ -2962,6 +3322,28 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "axios": "^1.9.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.5.1"
+    "react-router-dom": "^7.5.1",
+    "recharts": "^2.15.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import Join from './pages/Join';
 import Main from './pages/Main';
 import Keyword from './pages/Keyword';
 import My from './pages/My';
-import Cate from './pages/CategoryNews'
+import Cate from './pages/CategoryNews';
 
 function App() {
   return (
@@ -16,15 +16,13 @@ function App() {
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/join" element={<Join />} />
-        <Route path="/main" element={<Main />} />
+        <Route path="/category/:categoryName" element={<Cate />} />
         <Route path="/my" element={<My />} />
-        <Route path="/cate" element={<Cate />} />
         <Route path="/keyword/:keyword" element={<Keyword />} />
         <Route path="/" element={<Main />} /> {/* 제일 먼저 뜨는 페이지 */}
       </Routes>
     </>
   );
 }
-
 
 export default App;

--- a/src/components/AISummary.jsx
+++ b/src/components/AISummary.jsx
@@ -1,10 +1,64 @@
-import '../styles/aisummary.css';
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+import "../styles/aisummary.css";
 
 function AISummary() {
+  const [events, setEvents] = useState([]);
+  const { keyword } = useParams();
+
+  useEffect(() => {
+    if (!keyword) return;
+
+    axios
+      .get("https://newsummarize.com/api/search/timeline", {
+        params: { keyword },
+      })
+      .then((res) => {
+        const sorted = res.data.events.sort(
+          (a, b) => new Date(a.publishedAt) - new Date(b.publishedAt)
+        );
+        setEvents(sorted);
+      })
+      .catch((err) => {
+        console.error("타임라인 불러오기 실패:", err);
+      });
+  }, [keyword]);
+
+  // 날짜+시간 포맷 함수
+  const formatDateTime = (isoString) => {
+    const date = new Date(isoString);
+    const dateStr = date.toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+    const timeStr = date.toLocaleTimeString("ko-KR", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    return `${dateStr} ${timeStr}`;
+  };
+
   return (
     <div className="aisummary">
-      <h2>AI 요약 🪄</h2>
-      <p>요약된 뉴스 정보가 여기에 표시됩니다.</p>
+      <h2>타임라인 🪄</h2>
+      <div className="timeline-vertical">
+        {events.length === 0 ? (
+          <p>요약된 뉴스 정보가 여기에 표시됩니다.</p>
+        ) : (
+          events.map((event) => (
+            <div className="timeline-item" key={event.id}>
+              <div className="dot" />
+              <div className="timeline-content">
+                <div className="timeline-date">{formatDateTime(event.publishedAt)}</div>
+                <div className="timeline-title">{event.title}</div>
+                <div className="timeline-text">{event.content}</div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Category.jsx
+++ b/src/components/Category.jsx
@@ -1,22 +1,35 @@
 import React from 'react';
+import { useNavigate } from "react-router-dom";
 import '../styles/category.css';
 
 const categories = ['HOME', '정치', '경제', '사회', '생활/문화', 'IT/과학', '세계'];
 
 function Category({ selected, onSelect }) {
+  const navigate = useNavigate();
+
+  const handleClick = (cat) => {
+    onSelect(cat);  // 상태 업데이트 함수 호출
+
+    if (cat === 'HOME') {
+      navigate("/");
+    } else {
+      navigate(`/category/${encodeURIComponent(cat)}`);
+    }
+  };
+
   return (
-    <div className="category">
-      {categories.map((cat) => (
-        <button
-          key={cat}
-          onClick={() => onSelect(cat)}
-          className={selected === cat ? 'selected' : ''}
-        >
-          {cat}
-        </button>
-      ))}
-    </div>
-  );
+  <div className="category">
+    {categories.map((cat) => (
+      <button
+        key={cat}
+        onClick={() => handleClick(cat)}
+        className={selected === cat ? 'selected' : ''}
+      >
+        {cat}
+      </button>
+    ))}
+  </div>
+);
 }
 
 export default Category;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -17,7 +17,7 @@ function Header() {
   // 로고 클릭 시 검색어 초기화하고 메인 페이지로 이동
   const handleLogoClick = () => {
     setKeyword(""); // 검색어 초기화
-    navigate("/main", { replace: true }); // 쿼리 파라미터 없이 메인 페이지로 이동
+    navigate("/", { replace: true }); // 쿼리 파라미터 없이 메인 페이지로 이동
   };
 
   const handleSearchChange = (e) => {
@@ -60,8 +60,8 @@ function Header() {
           <button className="icon-button" 
             onClick={() => navigate(isLoggedIn ? "/my" : "/login")}>👤
           </button>
-          <button className="icon-button"
-            onClick={() => logout()}>❓
+          <button className="icon-button">
+            ❓
           </button>
         </div>
       )}

--- a/src/components/KeywordNews.jsx
+++ b/src/components/KeywordNews.jsx
@@ -1,5 +1,12 @@
 import '../styles/keywordnews.css';
 
+function formatDate(datetimeStr) {
+  if (!datetimeStr) return '';
+  const [date, time] = datetimeStr.split('T');
+  const hhmm = time?.slice(0, 5);
+  return `${date} ${hhmm}`;
+}
+
 function KeywordNews({ articles, title }) {
   return (
     <div className="keywordnews">
@@ -17,7 +24,7 @@ function KeywordNews({ articles, title }) {
                 <p className="keyword-news-title">{news.title}</p>
                 <p className="keyword-news-summary">{news.summary}</p>
               </div>
-              <p className="keyword-news-meta">{news.press} · {news.time}</p>
+              <p className="keyword-news-meta">{news.press} · {formatDate(news.time)}</p>
             </div>
           </li>
         ))}

--- a/src/components/MainNews.jsx
+++ b/src/components/MainNews.jsx
@@ -1,5 +1,12 @@
 import '../styles/mainnews.css';
 
+function formatDate(datetimeStr) {
+  if (!datetimeStr) return '';
+  const [date, time] = datetimeStr.split('T');
+  const hhmm = time?.slice(0, 5);
+  return `${date} ${hhmm}`;
+}
+
 function MainNews({ articles, title }) {
   return (
     <div className="mainnews">
@@ -17,7 +24,7 @@ function MainNews({ articles, title }) {
                 <p className="news-title">{news.title}</p>
                 <p className="news-summary">{news.summary}</p>
               </div>
-              <p className="news-meta">{news.press} · {news.time}</p>
+              <p className="news-meta">{news.press} · {formatDate(news.time)}</p>
             </div>
           </li>
         ))}

--- a/src/components/Recommend.jsx
+++ b/src/components/Recommend.jsx
@@ -1,5 +1,12 @@
 import '../styles/recommend.css';
 
+function formatDate(datetimeStr) {
+  if (!datetimeStr) return '';
+  const [date, time] = datetimeStr.split('T');
+  const hhmm = time?.slice(0, 5);
+  return `${date} ${hhmm}`;
+}
+
 function Recommend({ articles, title, isLoggedIn }) {
   return (
     <div className="recommend">
@@ -7,13 +14,19 @@ function Recommend({ articles, title, isLoggedIn }) {
       {isLoggedIn ? (
         <ul className="recommend-list">
           {articles.map((news, idx) => (
-            <li key={idx} className="recommend-item">
+            <li key={idx} className="recommend-item horizontal">
               <img
                 src={news.imageUrl || '/src/assets/default.png'}
                 alt="추천 뉴스 썸네일"
-                className="recommend-thumbnail"
+                className="recommend-thumbnail horizontal"
               />
-              <p className="recommend-title">{news.title}</p>
+              <div className="recommend-content">
+                <div>
+                  <p className="recommend-title">{news.title}</p>
+                  <p className="recommend-summary">{news.summary}</p>
+                </div>
+                <p className="recommend-meta">{news.press} · {formatDate(news.time)}</p>
+              </div>
             </li>
           ))}
         </ul>

--- a/src/components/Traffic.jsx
+++ b/src/components/Traffic.jsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";  // 추가
 import axios from "axios";
 import "../styles/traffic.css";
 
 function Traffic() {
+  const { keyword } = useParams();  // 키워드 받아오기
   const [imageUrl, setImageUrl] = useState(null);
 
   useEffect(() => {
-    const keyword = "대통령";      // ✅ 사용자 입력으로 대체 가능
-    const period = "weekly";       // ✅ 예: weekly, monthly 등
+    if (!keyword) return; // keyword 없으면 호출하지 않음
+
+    const period = "weekly";
 
     axios
       .get("https://newsummarize.com/api/search/analytics", {
@@ -15,7 +18,7 @@ function Traffic() {
           keyword,
           period,
         },
-        responseType: "blob", // ✅ 이미지니까 blob으로 받기
+        responseType: "blob",
       })
       .then((res) => {
         const imgUrl = URL.createObjectURL(res.data);
@@ -24,7 +27,7 @@ function Traffic() {
       .catch((err) => {
         console.error("트래픽 이미지 불러오기 실패:", err);
       });
-  }, []);
+  }, [keyword]);  // keyword가 바뀔 때마다 실행
 
   return (
     <div className="traffic">

--- a/src/pages/CategoryNews.jsx
+++ b/src/pages/CategoryNews.jsx
@@ -1,51 +1,73 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import axios from 'axios';
 import Category from '../components/Category';
 import '../styles/categorynews.css';
 
-const dummyArticles = [
-  { id: 1, title: "정치 뉴스 제목", summary: "정치 관련 주요 소식입니다.",
-    img: "https://via.placeholder.com/200x120/1976d2/ffffff?text=Politics"},
-  { id: 2, title: "경제 뉴스 제목", summary: "경제 관련 주요 소식입니다.",
-    img: "https://via.placeholder.com/200x120/4caf50/ffffff?text=Economy"},
-  { id: 3, title: "사회 뉴스 제목", summary: "사회 관련 주요 소식입니다.",
-    img: "https://via.placeholder.com/200x120/ff9800/ffffff?text=Society"},
-  { id: 4, title: "생활/문화 뉴스 제목", summary: "생활/문화 관련 주요 소식입니다.",
-    img: "https://via.placeholder.com/200x120/9c27b0/ffffff?text=Culture"},
-  { id: 5, title: "IT/과학 뉴스 제목", summary: "IT/과학 관련 주요 소식입니다.",
-    img: "https://via.placeholder.com/200x120/03a9f4/ffffff?text=IT"},
-  { id: 6, title: "세계 뉴스 제목", summary: "세계 관련 주요 소식입니다.",
-    img: "https://via.placeholder.com/200x120/ff5722/ffffff?text=World"},
-];
+function CategoryNews() {
+  const { categoryName } = useParams();
+  const [articles, setArticles] = useState([]);
 
-function truncate(text, maxLength) {
-  if (!text) return '';
-  return text.length > maxLength ? text.substring(0, maxLength) + '…' : text;
-}
+  useEffect(() => {
+     if (!categoryName) {
+    setArticles([]);
+    return;
+    }
 
-function CategoryNews({ articles = dummyArticles }) {
-const [selected, setSelected] = useState('HOME');
-const filtered = selected === 'HOME'
-    ? dummyArticles
-    : dummyArticles.filter(news => news.category === selected);
+    const normalizedCategory = categoryName.toLowerCase();
+
+    const fetchCategoryNews = async () => {
+      try {
+        const res = await axios.get('https://newsummarize.com/api/news/category', {
+          params: { category: normalizedCategory }
+        });
+        const data = res.data;
+
+        if (Array.isArray(data)) {
+          setArticles(data);
+        } else if (data && Array.isArray(data.articles)) {
+          setArticles(data.articles);
+        } else {
+          setArticles([]);
+        }
+      } catch (error) {
+        console.error('카테고리 뉴스 불러오기 실패:', error);
+        setArticles([]);
+      }
+    };
+
+    fetchCategoryNews();
+  }, [categoryName]);
 
   return (
-    <div className="news-wrapper">
-      <div className="news-list">
-        {articles.map((news) => (
-          <div key={news.id} className="news-item">
-            <div className="news-thumbnail">
-              <img src={news.img} alt="뉴스 썸네일" />
-            </div>
-            <div className="news-content">
-              <h3 className="news-title">{news.title}</h3>
-              <p className="news-summary">{truncate(news.summary, 100)}</p>
-              <div className="news-meta">
-                <span className="news-press">{news.press}</span>
-                <span className="news-time">{news.time}</span>
+     <div>
+      {/* 카테고리 목록 UI */}
+      <Category selected={categoryName} onSelect={() => {}} />
+
+      {/* 뉴스 리스트 UI */}
+      <div className="categorynews-container">
+        <ul className="categorynews-list">
+          {articles.length === 0 && categoryName !== 'HOME'}
+          {articles.map((article) => (
+            <li key={article.id} className="cate-news-item horizontal">
+              <img
+                src={article.imageUrl || '/src/assets/default.png'}
+                alt={article.title}
+                className="cate-news-thumbnail horizontal"
+              />
+              <div className="cate-news-content">
+                <div>
+                  <p className="cate-news-title">{article.title}</p>
+                  <p className="cate-news-summary">{article.content || '요약 정보가 없습니다.'}</p>
+                </div>
+                <p className="cate-news-meta">
+                  {article.publisher} · {new Date(article.publishedAt).toLocaleDateString()}
+                </p>
               </div>
-            </div>
-          </div>
-        ))}
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/src/pages/Keyword.jsx
+++ b/src/pages/Keyword.jsx
@@ -1,49 +1,56 @@
-import React from "react";
+import React, { useEffect, useState } from 'react';
+import axios from "axios";
 import { useParams } from "react-router-dom"; // 검색어 가져오기
 import KeywordNews from "../components/KeywordNews";
 import AISummary from "../components/AISummary";
 import Traffic from "../components/Traffic";
 import "../styles/keyword.css";
 
-const dummyArticles = [
-  {
-    title: "기사 헤드라인 1",
-    summary: "기사 요약 내용입니다.",
-    imageUrl: "",
-    press: "언론사",
-    time: "2025.04.22 13:00",
-  },
-  {
-    title: "기사 헤드라인 2",
-    summary: "기사 요약 내용입니다.",
-    imageUrl: "",
-    press: "언론사",
-    time: "2025.04.22 14:00",
-  },
-  {
-    title: "기사 헤드라인 3",
-    summary: "기사 요약 내용입니다.",
-    imageUrl: "",
-    press: "언론사",
-    time: "2025.04.22 15:00",
-  },
-];
-
 function Keyword() {
   const { keyword } = useParams(); // URL의 키워드 파라미터 추출
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!keyword) return;
+
+    const fetchKeywordNews = async () => {
+      try {
+        const res = await axios.get(`https://newsummarize.com/api/search`, {
+          params: { keyword },
+        });
+
+        const data = res.data.map((news) => ({
+          title: news.title,
+          summary: news.content,
+          imageUrl: news.imageUrl,
+          press: news.publisher,
+          time: news.publishedAt,
+        }));
+
+        setArticles(data);
+      } catch (err) {
+        console.error("키워드 뉴스 불러오기 실패:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchKeywordNews();
+  }, [keyword]);
 
   return (
     <div className="keyword-page">
       <main className="keyword-content">
-        <div className="keyword-container">
-          {/* 좌측 뉴스 영역 */}
-          <KeywordNews articles={dummyArticles} title={`"${keyword}" 관련 뉴스 📰`} />
+        {/* 1행: AI 요약 + 트래픽 */}
+        <div className="keyword-header-row">
+          <AISummary />
+          <Traffic />
+        </div>
 
-          {/* 우측 요약/트래픽 영역 */}
-          <div className="keyword-side">
-            <AISummary />
-            <Traffic />
-          </div>
+        {/* 2행: 뉴스 리스트 */}
+        <div className="keyword-news-row">
+          <KeywordNews articles={articles} title={`"${keyword}" 관련 뉴스 📰`} />
         </div>
       </main>
     </div>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -27,7 +27,7 @@ function Login() {
       localStorage.setItem("token", token); // 저장
       login(token); // useAuth() 안에서 필요 시 처리
       alert("로그인 성공!");
-      navigate("/main");
+      navigate("/");
     } catch (error) {
       console.error("로그인 실패:", error);
       alert("이메일 또는 비밀번호를 확인해주세요.");

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -8,11 +8,9 @@ import '../styles/main.css';
 
 function MainPage() {
   const { isLoggedIn, token } = useAuth();
-  const [selectedCategory, setSelectedCategory] = useState('HOME');
+
   const [mainNews, setMainNews] = useState([]);
   const [recommend, setRecommend] = useState([]);
-
-  console.log("MainPage 렌더링 - isLoggedIn:", isLoggedIn, "| token:", token);
 
   // 메인 뉴스 가져오기 (로그인 여부와 무관)
   useEffect(() => {
@@ -20,11 +18,10 @@ function MainPage() {
       try {
         const res = await axios.get('https://newsummarize.com/api/news/main');
         const mainNews = res.data;
-        console.log("메인 뉴스 응답:", mainNews);
         setMainNews(mainNews.map(news => ({
           imageUrl: news.imageUrl,
           title: news.title,
-          summary: news.content || "요약없음",
+          summary: news.content,
           press: news.publisher,
           time: news.publishedAt,
         })));
@@ -32,47 +29,43 @@ function MainPage() {
         console.error('메인 뉴스 불러오기 실패', error);
       }
     };
-
     fetchMainNews();
-  }, [selectedCategory]);
+  }, []);
 
   // 추천 뉴스 가져오기 (로그인 상태일 때만)
   useEffect(() => {
-    console.log("useEffect 실행됨 - isLoggedIn:", isLoggedIn, "| token:", token);
-
-    const fetchRecommend = async () => {
-      if (isLoggedIn && token) {
+    if (isLoggedIn && token) {
+      const fetchRecommend = async () => {
         try {
-          console.log("추천 뉴스 요청 시작");
           const res = await axios.get("https://newsummarize.com/api/news/recommend", {
             withCredentials: true,
             headers: {
               Authorization: `Bearer ${token}`,
             },
           });
-          console.log('추천 뉴스 응답:', res.data);
           setRecommend(res.data.map(news => ({
             imageUrl: news.imageUrl,
             title: news.title,
-            summary: news.content || "요약없음",
+            summary: news.content || "요약 정보가 없습니다",
             press: news.publisher,
             time: news.publishedAt,
           })));
         } catch (err) {
           console.error("추천 뉴스 오류:", err);
         }
-      } else {
-        console.log("추천 뉴스 요청 안 함 - 로그인 안 됨 또는 토큰 없음");
-        setRecommend([]); // 로그아웃 시 추천 뉴스 초기화
-      }
-    };
-    fetchRecommend();
+      };
+      fetchRecommend();
+    } else {
+      setRecommend([]);
+    }
   }, [isLoggedIn, token]);
 
   return (
     <div className="main-container">
-      <Category selected={selectedCategory} onSelect={setSelectedCategory} />
-
+       <Category
+        selected="HOME"
+        onSelect={() => {}}
+      />
       <div className="news-wrapper">
         <MainNews articles={mainNews} title="🔥 주요 뉴스" />
         <Recommend articles={recommend} title="🎯 추천" isLoggedIn={isLoggedIn} />

--- a/src/styles/aisummary.css
+++ b/src/styles/aisummary.css
@@ -1,5 +1,5 @@
 .aisummary {
-  background-color: #ffffff;
+  background-color: white;
   border-radius: 16px;
   padding: 20px 24px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
@@ -7,9 +7,11 @@
   color: #333;
   min-height: 200px;
   box-sizing: border-box;
+  max-height: 500px;
+  overflow-y: auto;
 }
 
-/* ✅ 제목 스타일 keywordnews 타이틀과 통일 */
+/* 제목 스타일 keywordnews 타이틀과 통일 */
 .aisummary h2 {
   font-size: 20px;
   margin-top: 6px;
@@ -17,4 +19,55 @@
   padding-left: 10px;
   border-left: 4px solid #2c7be5;
   color: #333;
+}
+
+/* 세로형 타임라인 스타일 */
+.timeline-vertical {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+  padding-left: 20px;
+  border-left: 2px solid #2c7be5;
+}
+
+.timeline-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  position: relative;
+}
+
+.timeline-item .dot {
+  width: 12px;
+  height: 12px;
+  background-color: #2c7be5;
+  border-radius: 50%;
+  position: absolute;
+  left: -7px;
+  top: 4px;
+}
+
+.timeline-content {
+  margin-left: 12px;
+}
+
+.timeline-date {
+  font-size: 13px;
+  font-weight: bold;
+  color: #2c7be5;
+}
+
+.timeline-title {
+  font-weight: 600;
+  margin-top: 4px;
+  font-size: 14px;
+  color: #333;
+}
+
+.timeline-text {
+  font-size: 13px;
+  margin-top: 2px;
+  color: #555;
+  line-height: 1.5;
 }

--- a/src/styles/categorynews.css
+++ b/src/styles/categorynews.css
@@ -1,78 +1,106 @@
-.news-wrapper {
-  width: 100%;
-  max-width: 800px;      /* 필요시 더 넓게 */
-  margin: 0 auto;
-  background: #f6f7fa;
-  border-radius: 16px;
-  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.04);
-  padding: 40px 0;
+/* 카테고리 뉴스 컨테이너 */
+.categorynews-container {
+  max-width: 1140px;
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.05);
+  margin-top: 32px;
 }
 
-.news-list {
-  width: 90%;
+/* 카테고리 뉴스 리스트 */
+.categorynews-list {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  margin-left: 40px;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
 }
 
-.news-item {
-  width: 100%;
+/* 카테고리 뉴스 아이템 */
+.cate-news-item.horizontal {
   display: flex;
-  gap: 20px;
-  padding: 16px;
-  border-radius: 8px;
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  align-items: center;
+  flex-direction: row;
+  align-items: flex-start;
+  padding: 8px;
+  background-color: #fff;
+  border-radius: 12px;
+  position: relative;
+  cursor: pointer;
+
+  overflow: hidden;
   box-sizing: border-box;
 }
 
-.news-thumbnail img {
-  width: 200px;
-  height: 120px;
+.cate-news-item.horizontal:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.cate-news-item.horizontal:hover .cate-news-title {
+  text-decoration: underline;
+}
+
+/* 이미지 섹션 (좌측) */
+.cate-news-thumbnail.horizontal {
+  width: 22%;
+  aspect-ratio: 5 / 3;
   object-fit: cover;
-  border-radius: 4px;
+  margin-right: 12px;
+  padding: 10px;
 }
 
-.news-content {
+/* 텍스트 컨테이너 */
+.cate-news-content {
   flex: 1;
-  min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 
-.news-title {
-  margin: 0 0 8px 0;
-  font-size: 18px;
-  font-weight: bold;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+/* 뉴스 제목 */
+.cate-news-title {
+  font-size: 17px;
+  font-weight: 600;
+  color: #333;
+  margin-top: 6px;
+  margin-bottom: 0px;
 
-.news-summary {
-  margin: 0 0 8px 0;
-  color: #555;
-  font-size: 15px;
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  text-overflow: ellipsis;
+
+  line-clamp: 1;
+  word-break: break-word;
+
+  line-height: 1.4;
+  min-height: calc(1.4em * 1);
 }
 
-.news-meta {
-  display: flex;
-  gap: 8px;
-  font-size: 14px;
-  color: #888;
-  flex-wrap: wrap;
-  margin-top: 4px;
+/* 뉴스 요약 */
+.cate-news-summary {
+  font-size: 15px;
+  color: #555;
+  line-height: 1.4;
+  margin-top: 8px;
+  margin-left: 4px;
+
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  word-break: break-word;
+
+  line-clamp: 4;
 }
 
-.news-press {
-  margin-right: 8px;
-  white-space: nowrap;
-}
-
-.news-time {
-  white-space: nowrap;
+/* 언론사 및 날짜 */
+.cate-news-meta {
+  position: absolute;
+  bottom: 6px;
+  font-size: 12px;
+  color: #999;
 }

--- a/src/styles/keyword.css
+++ b/src/styles/keyword.css
@@ -1,40 +1,37 @@
 .keyword-page {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  min-height: 100vh;
   background-color: #f5f6f8;
+  align-items: center;
 }
 
 .keyword-content {
-  padding: 15px;
-  background-color: #f5f6f8;
+  width: 100%;
+  max-width: 1140px;
+  padding: 20px;
+  box-sizing: border-box;
 }
 
-/* Main 페이지처럼 가운데 정렬 + 양옆 여백 */
-.keyword-container {
+/* AI요약 + 트래픽 */
+.keyword-header-row {
   display: flex;
   gap: 24px;
-  padding: 20px;
-  max-width: 1140px;
-  margin: 0 auto;   /* ⬅️ 가운데 정렬 */
-  height: 100%;
+  margin-bottom: 24px;
 }
 
-/* 좌측 뉴스 영역 */
-.keyword-container > .keywordnews {
-  flex: 3;
-}
-
-/* 우측 요약/트래픽 영역 */
-.keyword-side {
-  flex: 2;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  height: 100%;
-}
-
-/* 요약/트래픽 박스 높이 동일 */
-.keyword-side > * {
+.keyword-header-row > * {
   flex: 1;
+  background-color: white;
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+}
+
+/* 뉴스 리스트 */
+.keyword-news-row {
+  background-color: white;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
 }

--- a/src/styles/keywordnews.css
+++ b/src/styles/keywordnews.css
@@ -2,8 +2,7 @@
 .keywordnews {
     background-color: #ffffff;
     border-radius: 16px;
-    padding: 16px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+    padding: 10px;
     width: 100%;
     box-sizing: border-box;
 }
@@ -50,10 +49,9 @@
 
 /* 뉴스 이미지 (좌측) */
 .keyword-news-thumbnail.horizontal {
-    width: 46%;
-    aspect-ratio: 3 / 2;
+    width: 22%;
+    aspect-ratio: 5 / 3;
     object-fit: cover;
-    border-radius: 8px;
     margin-right: 12px;
     padding: 10px;
 }
@@ -72,15 +70,37 @@
     color: #333;
     margin-top: 6px;
     margin-bottom: 0px;
+
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    line-clamp: 1;
+    word-break: break-word;
+
+    line-height: 1.4;
+    min-height: calc(1.4em * 1);
 }
 
 /* 뉴스 요약 */
 .keyword-news-summary {
-    font-size: 14px;
+    font-size: 15px;
     color: #555;
     line-height: 1.4;
     margin-top: 8px;
     margin-left: 4px;
+
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    word-break: break-word;
+
+    line-clamp: 3;
 }
 
 /* 뉴스 언론사 · 날짜 */

--- a/src/styles/mainnews.css
+++ b/src/styles/mainnews.css
@@ -27,6 +27,9 @@
     border-radius: 12px;
     position: relative;
     cursor: pointer;
+
+    overflow: hidden;
+    box-sizing: border-box;
 }
 
 .news-item.horizontal:hover {
@@ -39,10 +42,9 @@
 
 /* 주요 뉴스 이미지 (좌측) */
 .news-thumbnail.horizontal {
-    width: 46%;
-    aspect-ratio: 3 / 2;
+    width: 42%;
+    aspect-ratio: 5 / 3;
     object-fit: cover;
-    border-radius: 8px;
     margin-right: 12px;
     padding: 10px;
 }
@@ -52,6 +54,8 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+
+    min-height: calc(1.5em * 3 + 40px);
 }
 
 /* 주요 뉴스 제목 */
@@ -61,6 +65,18 @@
     color: #333;
     margin-top: 6px;
     margin-bottom: 0px;
+
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    line-clamp: 2;
+    word-break: break-word;
+
+    line-height: 1.4;
+    min-height: calc(1.4em * 2);
 }
 
 /* 주요 뉴스 요약 */
@@ -70,12 +86,22 @@
     line-height: 1.4;
     margin-top: 8px;
     margin-left: 4px;
+
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    word-break: break-word;
+
+    line-clamp: 4;
 }
 
 /* 주요 뉴스 언론사 · 날짜 */
 .news-meta {
     position: absolute;
-    bottom: 6px; 
+    bottom: 6px;
     font-size: 12px;
     color: #999;
 }

--- a/src/styles/my.css
+++ b/src/styles/my.css
@@ -7,10 +7,10 @@ padding: 40px 0;
 overflow: hidden;
 display: flex;
 max-width: 900px;
-margin: 40px auto;
-background: #fafbfc;
+margin: 0px auto;
+background: white;
 border-radius: 20px;
-box-shadow: 0 2px 16px rgba(0,0,0,0.08);
+box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 padding: 40px 40px;
 align-items: flex-start;
 }
@@ -184,7 +184,6 @@ border: none;
 border-radius: 8px;
 cursor: pointer;
 font-weight: bold;
-transition: background 0.2s;
 }
 .mypage-logout-btn:hover {
 background: #2c7be5;

--- a/src/styles/recommend.css
+++ b/src/styles/recommend.css
@@ -6,8 +6,8 @@
     padding-left: 10px;
     border-left: 4px solid #2c7be5;
     color: #333;
-  }
-  
+}
+
 /* 추천 뉴스 리스트 */
 .recommend-list {
     list-style: none;
@@ -17,46 +17,75 @@
     flex-direction: column;
     gap: 8px;
 }
-  
+
 /* 추천 뉴스 아이템 카드 */
 .recommend-item {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    padding: 10px;
-    border-radius: 12px;
     background-color: #fff;
-    transition: box-shadow 0.2s ease;
+    border-radius: 12px;
+    padding: 6px 12px;
     cursor: pointer;
+    transition: box-shadow 0.2s ease;
 }
-  
+
 .recommend-item:hover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
-.recommend-item:hover .recommend-title {
-    text-decoration: underline;
-}
-  
-/* 추천 뉴스 이미지 */
+/* 이미지 위에 고정 */
 .recommend-thumbnail {
-    width: 94%;
-    aspect-ratio: 3 / 2;
+    width: 90%;
+    aspect-ratio: 5 / 3;
     object-fit: cover;
-    border-radius: 8px;
     padding: 5px;
+     margin: 0 auto;
 }
-  
-/* 추천 뉴스 제목 */
+
+/* 텍스트 컨테이너 */
+.recommend-content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+/* 제목 */
 .recommend-title {
-    font-size: 17px;
+    font-size: 16px;
     font-weight: 600;
     color: #333;
-    text-align: left;
-    align-self: flex-start;
-    margin-top: 5px;
-    margin-bottom: 0;
-    margin-left: 12px;
-    margin-right: 12px;
+
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
+    line-clamp: 2;
+    line-height: 1.4;
+    min-height: calc(1.4em * 2);
 }
-  
+
+/* 요약 */
+.recommend-summary {
+    font-size: 14px;
+    color: #555;
+    line-height: 1.4;
+
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
+    line-clamp: 4;
+
+    /* min-height: calc(1.4em * 6); */
+}
+
+/* 메타 */
+.recommend-meta {
+    font-size: 12px;
+    color: #999;
+    margin-top: auto;
+}

--- a/src/styles/traffic.css
+++ b/src/styles/traffic.css
@@ -1,15 +1,23 @@
 .traffic {
   background-color: #ffffff;
   border-radius: 16px;
-  padding: 20px 24px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  padding: 16px;
   font-size: 16px;
   color: #333;
   min-height: 160px;
   box-sizing: border-box;
 }
 
-/* ✅ 제목 통일 */
+.traffic-image {
+  width: 80%;
+  max-width: 400px;
+  height: auto;
+  display: block;
+  margin: 12px auto;
+  border-radius: 8px;
+}
+
+/* 제목 통일 */
 .traffic h2 {
   font-size: 20px;
   margin-top: 6px;


### PR DESCRIPTION
1. 카테고리 페이지 구현
- UI 구현 - Home 제외 다른 카테고리 눌렀을 때에 카테고리 배치, 기사 배치(중앙으로) 수정해야 함
- 라우팅 구현 - Category.jsx에서 구현, CategoryNews에 있는 useParams 없어도 될 것 같아서 삭제 고려

2.  키워드 페이지 구현 (포스터에 이미지 넣으려고 속성 구현)
- 트래픽은 일단 이미지로 받아옴 ("대통령" 키워드일 때만 받아와지는 이슈, 한결님이 코드 수정하셨다 해서 다시 해봐야 함)
- 관련 기사, AI 본문 요약은 잘 불러와지지만 로딩 시간 1분 이상 소요
- 타임라인은 디자인 수정해야 함 (+중복된 내용들 너무 많아서 한결님이 주말에 코드 수정하시기로)

3. 그 외 자잘한 것
- 도움말 아이콘에 있던 로그아웃 기능 제거
- 뉴스 제목과 본문들 일정 길이 넘어가지 않게 조정 (css에서 줄 수로 구현, 글자수로 하기에는 애매해서)

4. 할 일들
- 마이페이지 정보 백엔드에서 받아오기
- 로그아웃 버튼에 로그아웃 구현하기
- 키워드 페이지 완성도 높이기
- 그 외 자잘한 버그, 자잘한 라우팅 수정